### PR TITLE
Change Lanyrd URL to match Munich event

### DIFF
--- a/2/city/de-cologne.html
+++ b/2/city/de-cologne.html
@@ -21,7 +21,7 @@
           <img class="flag flag-de" src="../flag/blank.gif" alt="Germany">
           Cologne, Germany</h2>
         <h2>Saturday, May 10th 2014</h2>
-        <p><a href="http://lanyrd.com/2014/jscoderetreat/save-to-calendar/"> <img title="Add to Calendar" src="http://www.eventfellows.com/sites/default/files/CalIcon30px.png">Add to calendar</a></p>
+        <p><a href="http://lanyrd.com/2014/jscr2-cgn/save-to-calendar/"> <img title="Add to Calendar" src="http://www.eventfellows.com/sites/default/files/CalIcon30px.png">Add to calendar</a></p>
         <p><a href="../">JavaScript Code Retreat #2</a></p>
 
         <ul>
@@ -34,15 +34,15 @@
         <h1>Register</h1>
         <p>
           In order to have an estimate of how many people will
-          be coming please <a href="http://lanyrd.com/2014/jscoderetreat/" target="_blank">register on lanyrd</a>.
+          be coming please <a href="http://lanyrd.com/2014/jscr2-cgn/" target="_blank">register on lanyrd</a>.
           <br><br>
-          <a href="http://lanyrd.com/2014/jscoderetreat/" target="_blank" class="register">Register now</a>
+          <a href="http://lanyrd.com/2014/jscr2-cgn/" target="_blank" class="register">Register now</a>
         </p>
 
         <p>
           <!-- Add this where you want the output to appear -->
           <div class="lanyrd-target-participants">
-              <a href="http://lanyrd.com/2014/jscoderetreat/attendees/"
+              <a href="http://lanyrd.com/2014/jscr2-cgn/attendees/"
                   class="lanyrd-participants"
                   data-lanyrd-labels
                   data-lanyrd-iframe>


### PR DESCRIPTION
Please merge, Lanyrd links don't work at the moment.
