### PR TITLE
Use date filter to output the correct year

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -17,7 +17,7 @@
         86167 Augsburg<br>
         Germany</a><p><b>Phone:</b><a href="tel:+49821600806270">+49 821 600 806 270</a><br><p><b>Registrar of Companies:</b> Augsburg<br><b>Registrar number:</b> HRB 28613</p><p><b>Board of Directors:</b>&nbsp;Tobias von Klipstein<br></p></section></div><div class="imprint row"><section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy;2015, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section></div></footer><!-- Google Analytics: change UA-XXXXX-X to be your site's ID. --><script>
     (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
     function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;

--- a/downloads.html
+++ b/downloads.html
@@ -36,7 +36,7 @@
         86167 Augsburg<br>
         Germany</a><p><b>Phone:</b><a href="tel:+49821600806270">+49 821 600 806 270</a><br><p><b>Registrar of Companies:</b> Augsburg<br><b>Registrar number:</b> HRB 28613</p><p><b>Board of Directors:</b>&nbsp;Tobias von Klipstein<br></p></section></div><div class="imprint row"><section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy;2015, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section></div></footer><!-- Google Analytics: change UA-XXXXX-X to be your site's ID. --><script>
     (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
     function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;

--- a/events.html
+++ b/events.html
@@ -30,7 +30,7 @@
         86167 Augsburg<br>
         Germany</a><p><b>Phone:</b><a href="tel:+49821600806270">+49 821 600 806 270</a><br><p><b>Registrar of Companies:</b> Augsburg<br><b>Registrar number:</b> HRB 28613</p><p><b>Board of Directors:</b>&nbsp;Tobias von Klipstein<br></p></section></div><div class="imprint row"><section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy;2015, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section></div></footer><!-- Google Analytics: change UA-XXXXX-X to be your site's ID. --><script>
     (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
     function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;

--- a/howitworks.html
+++ b/howitworks.html
@@ -39,7 +39,7 @@
         86167 Augsburg<br>
         Germany</a><p><b>Phone:</b><a href="tel:+49821600806270">+49 821 600 806 270</a><br><p><b>Registrar of Companies:</b> Augsburg<br><b>Registrar number:</b> HRB 28613</p><p><b>Board of Directors:</b>&nbsp;Tobias von Klipstein<br></p></section></div><div class="imprint row"><section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy;2015, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section></div></footer><!-- Google Analytics: change UA-XXXXX-X to be your site's ID. --><script>
     (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
     function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
         86167 Augsburg<br>
         Germany</a><p><b>Phone:</b><a href="tel:+49821600806270">+49 821 600 806 270</a><br><p><b>Registrar of Companies:</b> Augsburg<br><b>Registrar number:</b> HRB 28613</p><p><b>Board of Directors:</b>&nbsp;Tobias von Klipstein<br></p></section></div><div class="imprint row"><section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy;2015, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section></div></footer><!-- Google Analytics: change UA-XXXXX-X to be your site's ID. --><script>
     (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=
     function(){(b[l].q=b[l].q||[]).push(arguments)});b[l].l=+new Date;

--- a/src/build.js
+++ b/src/build.js
@@ -2,6 +2,9 @@ var fs = require('fs');
 var swig = require('swig');
 var path = require('path');
 
+var now = new Date();
+var locals = {now: now};
+
 [
   'index',
   'howitworks',
@@ -11,6 +14,6 @@ var path = require('path');
 ].forEach(function(fileName) {
   var destFileName = path.join(__dirname, '..', fileName + '.html');
   var swigFileName = path.join(__dirname, 'pages', fileName + '.html.tpl');
-  fs.writeFileSync(destFileName, swig.renderFile(swigFileName));
+  fs.writeFileSync(destFileName, swig.renderFile(swigFileName, locals));
 });
 

--- a/src/chunks/footer.html.tpl
+++ b/src/chunks/footer.html.tpl
@@ -55,7 +55,7 @@
     <div class="imprint row">
       <section class="col-md-12">
         Brought to you by <a href="http://uxebu.com">uxebu</a> with <img src="img/icon%20heart.png" />
-        Copyright &copy; 2014, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
+        Copyright &copy; {{ now|date('Y') }}, uxebu. Designed by <a href="http://marcosantonocito.com">Marco Santonocito</a>.
       </section>
     </div>
   </footer>


### PR DESCRIPTION
### Issue

Footer shows the year 2014 next to copyright.
### Fix

Use `swig`'s built-in `date` filter within `src/chunks/footer.html.tpl` to output the current year.
